### PR TITLE
Fix staging iframe embed: allow kpsfinanciallab parent origin

### DIFF
--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -39,12 +39,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [token]);
 
   useEffect(() => {
-    const PARENT_ORIGIN = process.env.NEXT_PUBLIC_PARENT_ORIGIN || "";
+    // Accepts one origin or a comma-separated list (prod + staging parents).
+    const PARENT_ORIGINS = (process.env.NEXT_PUBLIC_PARENT_ORIGIN || "")
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean);
+    // Single configured origin → target postMessage precisely; multiple → "*"
+    // (the request carries no secret, only "REQUEST_AUTH_TOKEN").
+    const REQUEST_TARGET = PARENT_ORIGINS.length === 1 ? PARENT_ORIGINS[0] : "*";
 
     // Listen for JWT from parent iframe via postMessage
     const handleMessage = (event: MessageEvent) => {
       // Validate origin in production (skip if not configured)
-      if (PARENT_ORIGIN && event.origin !== PARENT_ORIGIN) return;
+      if (PARENT_ORIGINS.length && !PARENT_ORIGINS.includes(event.origin)) return;
 
       if (event.data?.type === "AUTH_TOKEN" && event.data?.token) {
         setToken(event.data.token);
@@ -83,7 +90,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     // Request token from parent (in case we loaded after parent sent it)
     if (window.parent !== window) {
-      window.parent.postMessage({ type: "REQUEST_AUTH_TOKEN" }, PARENT_ORIGIN || "*");
+      window.parent.postMessage({ type: "REQUEST_AUTH_TOKEN" }, REQUEST_TARGET);
     }
 
     // When NOT in iframe (standalone dev mode): short timeout, backend uses DEV_USER_ID fallback

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,9 +11,11 @@ server {
     server_name _;
     client_max_body_size 50M;
 
-    # Only allow embedding as iframe from Formula Finance
-    add_header Content-Security-Policy "frame-ancestors https://app.formulafinance.it" always;
-    add_header X-Frame-Options "ALLOW-FROM https://app.formulafinance.it" always;
+    # Only allow embedding as iframe from the parent apps (prod + staging).
+    # frame-ancestors is the directive browsers actually enforce; X-Frame-Options
+    # ALLOW-FROM is deprecated and ignored by Chrome/Firefox, so it is intentionally
+    # not set (a single-origin ALLOW-FROM cannot express the multi-origin list below).
+    add_header Content-Security-Policy "frame-ancestors https://app.formulafinance.it https://app.kpsfinanciallab.it" always;
 
     # Backend: API, docs, health
     location /api/ {


### PR DESCRIPTION
The staging parent app is served from https://app.kpsfinanciallab.it, but both the nginx CSP frame-ancestors and the AuthContext postMessage origin check only permitted https://app.formulafinance.it — so the iframe was blocked by the browser, and (once loaded) the parent's AUTH_TOKEN message was dropped.

- nginx/default.conf: add app.kpsfinanciallab.it to frame-ancestors; drop the X-Frame-Options ALLOW-FROM header (deprecated, ignored by modern browsers, and can't express a multi-origin list).
- AuthContext.tsx: NEXT_PUBLIC_PARENT_ORIGIN now accepts a comma-separated list of allowed parent origins, so one build serves prod + staging. REQUEST_AUTH_TOKEN targets the single origin when one is configured, else "*".